### PR TITLE
add the resource path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,17 +9,25 @@ mod shapes;
 use crate::game::MainState;
 use crate::game::{WINDOW_H, WINDOW_W};
 
+use std::path;
+use std::env;
+
 const TITLE: &str = "Fog of War";
 const GAME_ID: &str = "1.0";
 const AUTHOR: &str = "Berto";
 
 pub fn main() {
-  let mut c = conf::Conf::new();
-  c.window_setup.title = TITLE.to_string();
-  c.window_mode.height = WINDOW_H;
-  c.window_mode.width = WINDOW_W;
-  let ctx = &mut Context::load_from_conf(GAME_ID, AUTHOR, c).unwrap();
-  let state = &mut MainState::new().unwrap();
-  graphics::set_background_color(ctx, crate::colors::get_background());
-  event::run(ctx, state).unwrap();
+    let mut c = conf::Conf::new();
+    c.window_setup.title = TITLE.to_string();
+    c.window_mode.height = WINDOW_H;
+    c.window_mode.width = WINDOW_W;
+    let ctx = &mut Context::load_from_conf(GAME_ID, AUTHOR, c).unwrap();
+    if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
+        let mut path = path::PathBuf::from(manifest_dir);
+        path.push("resources");
+        ctx.filesystem.mount(&path, true);
+    }
+    let state = &mut MainState::new().unwrap();
+    graphics::set_background_color(ctx, crate::colors::get_background());
+    event::run(ctx, state).unwrap();
 }


### PR DESCRIPTION
Sorry, I ran `rustfmt` on the file so it shows more than what I changed. the `/resources` path needed to be added to the ggez vfs in order to grab the font file.